### PR TITLE
cssでのアニメーションの実装 #11

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -339,6 +339,8 @@ main.menuContainer {
 .menuContainer .slides figure.gridBox {
     display: none;
     margin-bottom: 20px;
+    /* TODO:displayがblockになるときにアニメーションさせる */
+    /* animationを使う */
 }
 @media screen and (min-width:768px) {
     main.menuContainer .slides {

--- a/css/style.css
+++ b/css/style.css
@@ -328,6 +328,14 @@ main.newsContainer {
 }
 
 /* menu */
+@keyframes menuAnimationIn {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}
 main.menuContainer {
     padding: 10px;
     display: flex;
@@ -339,8 +347,9 @@ main.menuContainer {
 .menuContainer .slides figure.gridBox {
     display: none;
     margin-bottom: 20px;
-    /* TODO:displayがblockになるときにアニメーションさせる */
-    /* animationを使う */
+    /* displayがblockになるときにアニメーションさせる */
+    animation-name: menuAnimationIn;
+    animation-duration: 1s;
 }
 @media screen and (min-width:768px) {
     main.menuContainer .slides {


### PR DESCRIPTION
## 概要

* fix #11 

menuのアニメーションを透過度で徐々に表示させる

## 使い方

自動で3秒毎に動きます。

## Request/Responseの主な変更点

なし

## 技術的変更点概要

cssの`@keyframe`と`animation`を使用

## DB変更点

無し

## テスト結果とテスト項目

- [x] ブラウザで正しく表示されることを確認。

## 今回保留した項目とTODOリスト

- **所謂フェードアウトの表示が出来ない**
  - `display`のnoneとblockをjsで切り替えているので大改修が必要だと思う。
  - 要件には無いので、一旦このまま…。
